### PR TITLE
shipment_decorator: Don't assume errors have codes

### DIFF
--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -24,7 +24,7 @@ module Spree
         force_refresh_rates if ENV['feature_refresh_rates_on_label_purchase'] == 'true'
         buy_rate
       rescue => error
-        raise error unless error.code == 'SHIPMENT.POSTAGE.FAILURE'
+        raise error unless error.try(:code) == 'SHIPMENT.POSTAGE.FAILURE'
 
         force_refresh_rates
         buy_rate


### PR DESCRIPTION
This addresses the NoMethodError seen here: https://careof.slack.com/archives/C1ZLL965N/p1534456038000100?thread_ts=1534164815.000183&cid=C1ZLL965N